### PR TITLE
Don't crash in MutableList<Float>.fill(color : Color) in AnimatedText…

### DIFF
--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/animation/AnimatedTextDocument.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/animation/AnimatedTextDocument.kt
@@ -7,7 +7,6 @@ import io.github.alexzhirkevich.compottie.dynamic.DynamicTextLayerProvider
 import io.github.alexzhirkevich.compottie.dynamic.derive
 import io.github.alexzhirkevich.compottie.internal.AnimationState
 import io.github.alexzhirkevich.compottie.internal.animation.expressions.ExpressionEvaluator
-import io.github.alexzhirkevich.compottie.internal.animation.expressions.RawExpressionEvaluator.evaluate
 import io.github.alexzhirkevich.compottie.internal.helpers.text.TextDocument
 import io.github.alexzhirkevich.compottie.internal.utils.toOffset
 import io.github.alexzhirkevich.compottie.internal.utils.toSize
@@ -40,19 +39,19 @@ internal class AnimatedTextDocument(
     var dynamic : DynamicTextLayerProvider? = null
 
     private val fillColorList by lazy {
-        ArrayList<Float>(4)
+        allocateArrayList(4)
     }
 
     private val strokeColorList by lazy {
-        ArrayList<Float>(4)
+        allocateArrayList(4)
     }
 
     private val sizeList by lazy {
-        ArrayList<Float>(2)
+        allocateArrayList(2)
     }
 
     private val positionList by lazy {
-        ArrayList<Float>(2)
+        allocateArrayList(2)
     }
 
 
@@ -131,3 +130,10 @@ private fun MutableList<Float>.fill(color : Color) : MutableList<Float> {
 
     return this
 }
+
+private fun MutableList<Float>.growToSize(size: Int): MutableList<Float> {
+    while (this.size < size) add(0f)
+    return this
+}
+
+private fun allocateArrayList(size: Int) = ArrayList<Float>(size).growToSize(size)

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/animation/AnimatedTextDocument.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/animation/AnimatedTextDocument.kt
@@ -13,7 +13,6 @@ import io.github.alexzhirkevich.compottie.internal.utils.toSize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import kotlin.collections.ArrayList
 
 @Serializable
 internal class AnimatedTextDocument(
@@ -131,9 +130,4 @@ private fun MutableList<Float>.fill(color : Color) : MutableList<Float> {
     return this
 }
 
-private fun MutableList<Float>.growToSize(size: Int): MutableList<Float> {
-    while (this.size < size) add(0f)
-    return this
-}
-
-private fun allocateArrayList(size: Int) = ArrayList<Float>(size).growToSize(size)
+private fun allocateArrayList(size: Int) = MutableList(size) { 0f }


### PR DESCRIPTION
…Document.kt

When setting a value at a specific position in a list, the list must have size up to the given position.

This commit fixes #17.