### PR TITLE
Add support for wildcard and globstar pattern matching in dynamic pro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,29 @@ val painter = rememberLottiePainter(
 ) 
 ```
 
+You can also use wildcards for declaring dynamic properties, where `**` is any level deep wildcard
+and `*` is one level deep.
+
+```kotlin
+val painter = rememberLottiePainter(
+    composition = composition,
+    dynamicProperties = rememberLottieDynamicProperties {
+        
+        // for each layer named 'Shape Layer 4' on any level deep
+        shapeLayer("**", "Shape Layer 4") {
+            transform {
+                rotation { current -> current * progress }
+            }
+            // for each fill named 'Fill 4' on the 2nd level deep
+            fill("*", "Fill 4") {
+                color { Color.Red }
+                alpha { .5f }
+            }
+        }
+    }
+) 
+```
+
 Note, that final property building blocks (such as rotations, color, alpha) are called on EACH ANIMATION FRAME and should be cached if they don't rely on progress and have allocations or hard computations.
 
 More info about dynamic properties for those who is not familiar with AE / Lottie format can be found [here](/dynamic_properties.md).

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/DynamicShapeLayer.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/DynamicShapeLayer.kt
@@ -6,8 +6,7 @@ public interface DynamicShapeLayer: DynamicLayer {
      * Configure generic dynamic shape.
      *
      * @param path is a path to the shape relative to the shape layer.
-     * If [path] is not set, the [builder] configuration will be be applied to each shape in
-     * the current layer/[group] recursively
+     * Can contain '**' and '*' wildcards
      *
      * @param builder shape dynamic configuration
      * */
@@ -42,8 +41,7 @@ public interface DynamicShapeLayer: DynamicLayer {
      * Configure dynamic stroke.
      *
      * @param path is a path to the stroke shape relative to the shape layer.
-     * If [path] is not set, the [builder] configuration will be be applied to each stroke in
-     * the current layer/[group] recursively
+     * Can contain '**' and '*' wildcards
      *
      * @param builder shape dynamic configuration
      * */
@@ -56,8 +54,7 @@ public interface DynamicShapeLayer: DynamicLayer {
      * Configure dynamic fill.
      *
      * @param path is a path to the fill shape relative to the shape layer.
-     * If [path] is not set, the [builder] configuration will be be applied to each fill in
-     * the current layer/[group] recursively
+     * Can contain '**' and '*' wildcards
      *
      * @param builder shape dynamic configuration
      * */
@@ -70,8 +67,7 @@ public interface DynamicShapeLayer: DynamicLayer {
      * Configure dynamic ellipse.
      *
      * @param path is a path to the ellipse shape relative to the shape layer.
-     * If [path] is not set, the [builder] configuration will be be applied to each ellipse in
-     * the current layer/[group] recursively
+     * Can contain '**' and '*' wildcards
      *
      * @param builder shape dynamic configuration
      * */
@@ -84,8 +80,7 @@ public interface DynamicShapeLayer: DynamicLayer {
      * Configure dynamic rect.
      *
      * @param path is a path to the rect shape relative to the shape layer.
-     * If [path] is not set, the [builder] configuration will be be applied to each rect in
-     * the current layer/[group] recursively
+     * Can contain '**' and '*' wildcards
      *
      * @param builder shape dynamic configuration
      * */
@@ -98,8 +93,7 @@ public interface DynamicShapeLayer: DynamicLayer {
      * Configure dynamic rect.
      *
      * @param path is a path to the polystar shape relative to the shape layer.
-     * If [path] is not set, the [builder] configuration will be be applied to each polystar in
-     * the current layer/[group] recursively
+     * Can contain '**' and '*' wildcards
      *
      * @param builder shape dynamic configuration
      * */

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/PathMatching.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/PathMatching.kt
@@ -1,5 +1,7 @@
 package io.github.alexzhirkevich.compottie.dynamic
 
+internal fun Iterable<String>.containsWildcards() = any { it == "**" || it == "*" }
+
 internal fun pathMatches(path: String, pattern: String): Boolean = pathMatches(
     path = path.split(LayerPathSeparator),
     pattern = pattern.split(LayerPathSeparator)

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/PathMatching.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/PathMatching.kt
@@ -1,0 +1,43 @@
+package io.github.alexzhirkevich.compottie.dynamic
+
+internal fun pathMatches(path: String, pattern: String): Boolean = pathMatches(
+    path = path.split(LayerPathSeparator),
+    pattern = pattern.split(LayerPathSeparator)
+)
+
+internal fun pathMatches(path: List<String>, pattern: List<String>): Boolean {
+    // Both patter and path are empty => we have found a match
+    if (pattern.isEmpty()) return path.isEmpty()
+    if (path.isEmpty()) {
+        if (pattern.isEmpty()) return true
+        // If path is empty but not the pattern, we need to check whether the pattern ends with
+        // a globstar that permits 0 matches.
+        if (pattern.all { it == "**" }) return true
+        return false
+    }
+    val pathPart = path.first()
+    return when (val patternPart = pattern.first()) {
+        // For a wildcard we skip the current path element and advance in the pattern list.
+        "*" -> pathMatches(
+            path = path.dropFirst(),
+            pattern = pattern.dropFirst()
+        )
+
+        // For a globstar we check a subpath against the same pattern (to match multiple path
+        // elements) and the same path against the pattern excluding the globastar
+        // (to match 0 path elements).
+        "**" -> pathMatches(path = path.dropFirst(), pattern = pattern) ||
+                pathMatches(path = path, pattern = pattern.dropFirst())
+
+        // For a named pattern element we check if it equals to the path element and advance
+        // in both lists.
+        else -> patternPart == pathPart &&
+                pathMatches(
+                    path = path.dropFirst(),
+                    pattern = pattern.dropFirst()
+                )
+    }
+}
+
+// Using subList for performance.
+private fun List<String>.dropFirst() = subList(fromIndex = 1, toIndex = size)

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicCompositionProvider.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicCompositionProvider.kt
@@ -26,10 +26,11 @@ internal class DynamicCompositionProvider : LottieDynamicProperties {
     }
 
     private fun <T : DynamicLayerProvider> appendLayer(path: Array<out String>, instance: T) {
-        if (path.any { it == "**" || it == "*" }) {
-            layersByPattern.add(path.toList() to  instance)
+        val list = path.toList()
+        if (list.containsWildcards()) {
+            layersByPattern.add(list to instance)
         } else {
-            layers[path.joinToString(LayerPathSeparator, LayerPathSeparator)] = instance
+            layers[list.joinToString(LayerPathSeparator, LayerPathSeparator)] = instance
         }
     }
 

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicCompositionProvider.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicCompositionProvider.kt
@@ -2,32 +2,14 @@ package io.github.alexzhirkevich.compottie.dynamic
 
 import io.github.alexzhirkevich.compottie.internal.layers.ResolvingPath
 
-private data class LayerWithPathPattern(
-    val pathPattern: List<String>,
-    val layer: DynamicLayerProvider
-)
 
 @PublishedApi
 internal class DynamicCompositionProvider : LottieDynamicProperties {
 
     private val layers = mutableMapOf<String, DynamicLayerProvider>()
-    private val layersByPattern = mutableListOf<LayerWithPathPattern>()
+    private val layersByPattern = mutableListOf<Pair<List<String>,DynamicLayerProvider>>()
 
     override fun shapeLayer(vararg path: String, builder: DynamicShapeLayer.() -> Unit) {
-//        val p = path.joinToString(LayerPathSeparator, LayerPathSeparator)
-//
-//        val provider = when(val existent = layers[p]) {
-//            is DynamicShapeLayerProvider -> existent
-//            is DynamicLayerProvider -> DynamicShapeLayerProvider().apply {
-//                transform = existent.transform
-//            }
-//
-//            else -> DynamicShapeLayerProvider()
-//        }
-//
-//        provider.apply(builder)
-//
-//        layers[p] = provider
         appendLayer(path, DynamicShapeLayerProvider().apply(builder))
     }
 
@@ -45,7 +27,7 @@ internal class DynamicCompositionProvider : LottieDynamicProperties {
 
     private fun <T : DynamicLayerProvider> appendLayer(path: Array<out String>, instance: T) {
         if (path.any { it == "**" || it == "*" }) {
-            layersByPattern.add(LayerWithPathPattern(pathPattern = path.toList(), layer = instance))
+            layersByPattern.add(path.toList() to  instance)
         } else {
             layers[path.joinToString(LayerPathSeparator, LayerPathSeparator)] = instance
         }

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicCompositionProvider.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicCompositionProvider.kt
@@ -38,7 +38,7 @@ internal class DynamicCompositionProvider : LottieDynamicProperties {
         // Prioritize an exact match over a pattern match
         if (exactLayer != null) return exactLayer
 
-        val pathParts = path.path.split(LayerPathSeparator)
+        val pathParts = path.path.split(LayerPathSeparator).filter(String::isNotEmpty)
         for (patternLayer in layersByPattern) {
             val (pattern, layer) = patternLayer
             if (pathMatches(path = pathParts, pattern = pattern)) return layer

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicShapeLayerProvider.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicShapeLayerProvider.kt
@@ -59,7 +59,7 @@ internal class DynamicShapeLayerProvider(
     private fun <S : DynamicShape> getInternal(path: String, clazz: KClass<S>): DynamicShape? {
         nRoot.shapes[path]?.let { return it }
 
-        val pathParts = path.split(LayerPathSeparator)
+        val pathParts = path.split(LayerPathSeparator).filter(String::isNotEmpty)
         for (patternLayer in shapesByPattern) {
             val (pattern, shape) = patternLayer
             if (pathMatches(path = pathParts, pattern = pattern) && clazz.isInstance(shape))

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicShapeLayerProvider.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/dynamic/_DynamicShapeLayerProvider.kt
@@ -49,7 +49,7 @@ internal class DynamicShapeLayerProvider(
         getInternal(path, S::class) as S?
 
     private inline operator fun <reified T : DynamicShape> set(path: List<String>, instance: T) {
-        if (path.any { it == "**" || it == "*" }) {
+        if (path.containsWildcards()) {
             nRoot.shapesByPattern.add(path.toList() to  instance)
         } else {
             nRoot.shapes[layerPath(basePath, path.joinToString(LayerPathSeparator))] = instance

--- a/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/BaseStrokeShape.kt
+++ b/compottie/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/BaseStrokeShape.kt
@@ -105,7 +105,10 @@ internal abstract class BaseStrokeShape() : Shape, DrawingContent {
             strokeJoin = lineJoin.asStrokeJoin()
         }
     }
-    private val pm = ExtendedPathMeasure()
+
+    private val pm by lazy {
+        ExtendedPathMeasure()
+    }
 
     private val dashPattern by lazy {
         strokeDash?.filter { it.dashType != DashType.Offset }?.map { it.value }?.let {

--- a/compottie/src/commonTest/kotlin/io/github/alexzhirkevich/compottie/dynamic/PathMatchingTest.kt
+++ b/compottie/src/commonTest/kotlin/io/github/alexzhirkevich/compottie/dynamic/PathMatchingTest.kt
@@ -1,0 +1,41 @@
+package io.github.alexzhirkevich.compottie.dynamic
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PathMatchingTest {
+
+    @Test
+    fun exactPatterns() {
+        assertTrue(pathMatches(path = "a", pattern = "a"))
+        assertFalse(pathMatches(path = "a/b", pattern = "a/c"))
+    }
+
+    @Test
+    fun patternsWithWildcard() {
+        assertTrue(pathMatches(path = "a", pattern = "*"))
+        assertFalse(pathMatches(path = "a/b", pattern = "*"))
+        assertTrue(pathMatches(path = "a/b", pattern = "*/*"))
+        assertTrue(pathMatches(path = "a/b", pattern = "*/b"))
+        assertTrue(pathMatches(path = "a/b", pattern = "a/*"))
+        assertFalse(pathMatches(path = "a/b/c", pattern = "a/*"))
+        assertFalse(pathMatches(path = "a/b/c", pattern = "*/*"))
+    }
+
+    @Test
+    fun patternsWithGlobstar() {
+        assertTrue(pathMatches(path = "a", pattern = "**"))
+        assertTrue(pathMatches(path = "a/b", pattern = "**"))
+        assertTrue(pathMatches(path = "a/b", pattern = "*/**"))
+        assertTrue(pathMatches(path = "a/b", pattern = "**/b"))
+        assertTrue(pathMatches(path = "b", pattern = "**/b"))
+        assertFalse(pathMatches(path = "a/b", pattern = "**/c"))
+        assertTrue(pathMatches(path = "a/b/c/d/e", pattern = "**/c/**"))
+        assertTrue(pathMatches(path = "c/d/e", pattern = "**/c/**"))
+        assertTrue(pathMatches(path = "a/b/c", pattern = "**/c/**"))
+        assertTrue(pathMatches(path = "a/b/c", pattern = "**/c"))
+        assertTrue(pathMatches(path = "a/b", pattern = "a/**"))
+        assertTrue(pathMatches(path = "a/b/c", pattern = "a/**"))
+    }
+}

--- a/dynamic_properties.md
+++ b/dynamic_properties.md
@@ -33,6 +33,29 @@ val painter = rememberLottiePainter(
 ) 
 ```
 
+You can also use wildcards for declaring dynamic properties, where `**` is any level deep wildcard
+and `*` is one level deep.
+
+```kotlin
+val painter = rememberLottiePainter(
+    composition = composition,
+    dynamicProperties = rememberLottieDynamicProperties {
+        
+        // for each layer named 'Shape Layer 4' on any level deep
+        shapeLayer("**", "Shape Layer 4") {
+            transform {
+                rotation { current -> current * progress }
+            }
+            // for each fill named 'Fill 4' on the 2nd level deep
+            fill("*", "Fill 4") {
+                color { Color.Red }
+                alpha { .5f }
+            }
+        }
+    }
+) 
+```
+
 For a person that isn't familiar with After Effects / [Lottie JSON schema](https://lottiefiles.github.io/lottie-docs/schema/) this might seem scary, but it is pretty simple.
 
 # Lottie Layers

--- a/example/shared/src/commonMain/kotlin/TestPlayground.kt
+++ b/example/shared/src/commonMain/kotlin/TestPlayground.kt
@@ -43,6 +43,7 @@ import io.github.alexzhirkevich.compottie.ExperimentalCompottieApi
 import io.github.alexzhirkevich.compottie.LottieComposition
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
 import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
+import io.github.alexzhirkevich.compottie.dynamic.rememberLottieDynamicProperties
 import io.github.alexzhirkevich.compottie.rememberLottieComposition
 import io.github.alexzhirkevich.compottie.rememberLottiePainter
 import io.github.alexzhirkevich.compottie.rememberResourcesAssetsManager
@@ -237,6 +238,26 @@ public fun AllExamples(){
                 LottieCompositionSpec.ResourceString(it)
             }
 
+            val dynamicProperties = rememberLottieDynamicProperties {
+                if (it == BOUNCING_BALL) {
+                    shapeLayer("**", "Layer") {
+                        fill {
+                            color {
+                                Color.Yellow
+                            }
+                        }
+                    }
+                } else if (it == TEXT) {
+                    textLayer("**", "Text Layer") {
+                        text {
+                            "Goodbye"
+                        }
+                        fillColor {
+                            Color.Red
+                        }
+                    }
+                }
+            }
             Image(
                 painter = rememberLottiePainter(
                     composition = composition,
@@ -250,6 +271,7 @@ public fun AllExamples(){
                             else -> null
                         }
                     },
+                    dynamicProperties = dynamicProperties
                 ),
                 contentDescription = null,
                 modifier = Modifier

--- a/example/shared/src/commonMain/kotlin/TestPlayground.kt
+++ b/example/shared/src/commonMain/kotlin/TestPlayground.kt
@@ -237,7 +237,6 @@ public fun AllExamples(){
                 LottieCompositionSpec.ResourceString(it)
             }
 
-
             Image(
                 painter = rememberLottiePainter(
                     composition = composition,

--- a/example/shared/src/commonMain/kotlin/TestPlayground.kt
+++ b/example/shared/src/commonMain/kotlin/TestPlayground.kt
@@ -43,7 +43,6 @@ import io.github.alexzhirkevich.compottie.ExperimentalCompottieApi
 import io.github.alexzhirkevich.compottie.LottieComposition
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
 import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
-import io.github.alexzhirkevich.compottie.dynamic.rememberLottieDynamicProperties
 import io.github.alexzhirkevich.compottie.rememberLottieComposition
 import io.github.alexzhirkevich.compottie.rememberLottiePainter
 import io.github.alexzhirkevich.compottie.rememberResourcesAssetsManager
@@ -238,26 +237,7 @@ public fun AllExamples(){
                 LottieCompositionSpec.ResourceString(it)
             }
 
-            val dynamicProperties = rememberLottieDynamicProperties {
-                if (it == BOUNCING_BALL) {
-                    shapeLayer("**", "Layer") {
-                        fill {
-                            color {
-                                Color.Yellow
-                            }
-                        }
-                    }
-                } else if (it == TEXT) {
-                    textLayer("**", "Text Layer") {
-                        text {
-                            "Goodbye"
-                        }
-                        fillColor {
-                            Color.Red
-                        }
-                    }
-                }
-            }
+
             Image(
                 painter = rememberLottiePainter(
                     composition = composition,
@@ -271,7 +251,6 @@ public fun AllExamples(){
                             else -> null
                         }
                     },
-                    dynamicProperties = dynamicProperties
                 ),
                 contentDescription = null,
                 modifier = Modifier


### PR DESCRIPTION
…perties

This commit enables layer path matching for dynamic properties in a similar fashion to the official Lottie library. Wildcard "*" pattern path segment matches exactly one path segment. Globstar "**" pattern path segment, matches 0, 1 or many path segments.

Example usage:

    dynamicProperties = rememberLottieDynamicProperties {
        // Match "Shape Layer 4" at any depth.
        shapeLayer("**", "Shape Layer 4") {
            // Match "Fill 3" on the second level, e.g. "ABC/Fill 3" or "XYZ/Fill 3"
            fill("*", "Fill 3") {
                color { Color.Red }
                alpha { .5f }
            }
        }
    }

Current limitations: only the first matching dynamic property is applied.

This commit fixes #9.