### PR TITLE
Remove transitive dependency on atomicfu (Fixes #28)

### DIFF
--- a/compottie-dot/build.gradle.kts
+++ b/compottie-dot/build.gradle.kts
@@ -9,7 +9,9 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":compottie"))
-            implementation(compose.ui)
+            implementation(compose.ui) {
+                exclude("org.jetbrains.kotlinx", "atomicfu")
+            }
             implementation(libs.serialization)
             implementation(libs.okio)
             implementation(libs.okio.fakefilesystem)

--- a/compottie-network-core/build.gradle.kts
+++ b/compottie-network-core/build.gradle.kts
@@ -7,7 +7,9 @@ kotlin {
         commonMain.dependencies {
             api(project(":compottie"))
             implementation(project(":compottie-dot"))
-            implementation(compose.ui)
+            implementation(compose.ui) {
+                exclude("org.jetbrains.kotlinx", "atomicfu")
+            }
             implementation(libs.serialization)
             api(libs.okio)
             implementation(libs.coroutines.core)

--- a/compottie-network/build.gradle.kts
+++ b/compottie-network/build.gradle.kts
@@ -8,7 +8,9 @@ kotlin {
             api(project(":compottie"))
             api(project(":compottie-network-core"))
             implementation(project(":compottie-dot"))
-            implementation(compose.ui)
+            implementation(compose.ui) {
+                exclude("org.jetbrains.kotlinx", "atomicfu")
+            }
             implementation(libs.serialization)
             api(libs.okio)
             api(libs.ktor.client.core)

--- a/compottie-resources/build.gradle.kts
+++ b/compottie-resources/build.gradle.kts
@@ -3,8 +3,12 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":compottie"))
-            implementation(compose.ui)
-            implementation(compose.components.resources)
+            implementation(compose.ui) {
+                exclude("org.jetbrains.kotlinx", "atomicfu")
+            }
+            implementation(compose.components.resources) {
+                exclude("org.jetbrains.kotlinx", "atomicfu")
+            }
             implementation(libs.coroutines.core)
         }
     }

--- a/compottie/build.gradle.kts
+++ b/compottie/build.gradle.kts
@@ -11,16 +11,22 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation(compose.foundation)
+            implementation(compose.foundation) {
+                exclude("org.jetbrains.kotlinx", "atomicfu")
+            }
             implementation(libs.serialization)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
             @OptIn(ExperimentalComposeLibrary::class)
-            implementation(compose.uiTest)
+            implementation(compose.uiTest) {
+                exclude("org.jetbrains.kotlinx", "atomicfu")
+            }
         }
         desktopTest.dependencies {
-            implementation(compose.desktop.currentOs)
+            implementation(compose.desktop.currentOs) {
+                exclude("org.jetbrains.kotlinx", "atomicfu")
+            }
         }
 
         androidMain.dependencies {


### PR DESCRIPTION
(Fixes #28 )

Example project fails to sync because of miscallenious atomicfu versions. This leads to crash when trying to build example app. 
This pull request removes transitive dependency on atomicfu v0.23.2 from compose dependencies. 