### PR TITLE
fix: thread-safety for concurrent Lottie animations

### DIFF
--- a/compottie-core/src/androidMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformPath.android.kt
+++ b/compottie-core/src/androidMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformPath.android.kt
@@ -11,13 +11,12 @@ internal actual fun ExtendedPathMeasure() : ExtendedPathMeasure = AndroidExtende
     android.graphics.PathMeasure()
 )
 
-private val tempAndroidMatrix = android.graphics.Matrix()
 internal actual fun Path.addPath(path: Path, matrix: Matrix) : Path {
+    val androidMatrix = android.graphics.Matrix()
     return asAndroidPath().apply {
         addPath(
             path.asAndroidPath(),
-            tempAndroidMatrix.apply {
-                reset()
+            androidMatrix.apply {
                 setFromInternal(matrix)
             }
         )

--- a/compottie-core/src/androidMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformShader.android.kt
+++ b/compottie-core/src/androidMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformShader.android.kt
@@ -10,8 +10,6 @@ import androidx.compose.ui.graphics.RadialGradientShader
 import androidx.compose.ui.graphics.TileMode
 
 
-private val tempMatrix = android.graphics.Matrix()
-
 internal actual fun MakeLinearGradient(
     from : Offset,
     to : Offset,
@@ -26,8 +24,9 @@ internal actual fun MakeLinearGradient(
     tileMode = tileMode,
     colors = colors
 ).apply {
-    tempMatrix.setFromInternal(matrix)
-    setLocalMatrix(tempMatrix)
+    val localMatrix = android.graphics.Matrix()
+    localMatrix.setFromInternal(matrix)
+    setLocalMatrix(localMatrix)
 }
 
 internal actual fun MakeRadialGradient(
@@ -44,8 +43,9 @@ internal actual fun MakeRadialGradient(
     tileMode = tileMode,
     colors = colors
 ).apply {
-    tempMatrix.setFromInternal(matrix)
-    setLocalMatrix(tempMatrix)
+    val localMatrix = android.graphics.Matrix()
+    localMatrix.setFromInternal(matrix)
+    setLocalMatrix(localMatrix)
 }
 
 internal actual fun Paint.setBlurMaskFilter(radius: Float, isImage : Boolean) {

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/LottiePainter.core.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/LottiePainter.core.kt
@@ -99,7 +99,7 @@ public fun rememberLottiePainter(
         null -> null
     }
 
-    val copy = dp != null
+    val copy = true
 
     val coroutineScope = rememberCoroutineScope()
 

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/LottiePainter.core.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/LottiePainter.core.kt
@@ -99,21 +99,19 @@ public fun rememberLottiePainter(
         null -> null
     }
 
-    val copy = true
-
     val coroutineScope = rememberCoroutineScope()
 
     val painter by produceState<LottiePainter?>(
-        null, composition, copy, coroutineScope
+        null, composition, coroutineScope
     ) {
 
         if (composition != null) {
 
-            val comp = if (copy) composition.deepCopy() else composition
+            val comp = composition.deepCopy()
 
             val assets = if (comp.hasAssets) {
                 async(coroutineContext) {
-                    comp.loadAssets(assetsManager ?: EmptyAssetsManager, copy)
+                    comp.loadAssets(assetsManager ?: EmptyAssetsManager, true)
                 }
             } else {
                 null

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/animation/AnimatedShape.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/animation/AnimatedShape.kt
@@ -280,7 +280,7 @@ internal abstract class AnimatedShape : AnimatedProperty<Path>, ExpressionHolder
         override fun raw(state: AnimationState): Path {
             return state.composition.animation.slots.shape(sid)
                 ?.interpolated(state)
-                ?: EmptyPath.apply { reset() }
+                ?: Path()
         }
     }
 }

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/animation/expressions/Layer.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/animation/expressions/Layer.kt
@@ -44,8 +44,6 @@ internal fun JSLayerToCompOrWorld(
     }
 }
 
-private val conversionMatrix = Matrix()
-
 private fun ScriptRuntime.convert(
     layer: Layer,
     point : List<Number>,
@@ -54,6 +52,7 @@ private fun ScriptRuntime.convert(
     toComp : Boolean,
 ) : JsAny {
 
+    val conversionMatrix = Matrix()
     val layerMatrix = layer.totalTransformMatrix(state, toComp = toComp)
     val compMatrix = state.thisComp.transformMatrix(state)
 

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/assets/PrecompositionAsset.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/assets/PrecompositionAsset.kt
@@ -12,6 +12,10 @@ internal class PrecompositionAsset(
     val layers : List<Layer>
 ) : LottieAsset {
     override fun copy(): LottieAsset {
-        return this
+        return PrecompositionAsset(
+            id = id,
+            name = name,
+            layers = layers.map(Layer::deepCopy)
+        )
     }
 }

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/helpers/CompoundTrimPath.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/helpers/CompoundTrimPath.kt
@@ -50,17 +50,15 @@ internal fun Path.applyTrimPath(trimPath: TrimPathShape, state: AnimationState) 
 }
 
 
-private val pathMeasure by lazy {
-    ExtendedPathMeasure()
-}
-private val tempPath = Path()
-private val tempPath2 = Path()
-
 internal fun Path.applyTrimPath(
     startValue: Float,
     endValue: Float,
     offsetValue: Float,
 ) {
+    val pathMeasure = ExtendedPathMeasure()
+    val tempPath = Path()
+    val tempPath2 = Path()
+
     pathMeasure.setPath(this, false)
 
     val length: Float = pathMeasure.length

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/utils/Matrix.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/utils/Matrix.kt
@@ -8,10 +8,6 @@ import kotlin.math.hypot
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
-private val tempMatrixConcat = Matrix()
-private val tempMatrixTransform = Matrix()
-
-
 internal val IdentityMatrix = Matrix()
 
 internal fun Matrix.preTranslate(x : Float, y : Float) {
@@ -36,9 +32,10 @@ internal fun Matrix.preConcat(other : Matrix) {
         return
     }
 
-    tempMatrixConcat.fastSetFrom(other)
-    tempMatrixConcat.timesAssign(this)
-    fastSetFrom(tempMatrixConcat)
+    val temp = Matrix()
+    temp.fastSetFrom(other)
+    temp.timesAssign(this)
+    fastSetFrom(temp)
 
 //    timesAssign(other)
 }
@@ -79,8 +76,7 @@ internal fun Matrix.preRotateX(degree : Float) {
     if (degree.absoluteValue < Float.MIN_VALUE) {
         return
     }
-    preConcat(tempMatrixTransform.apply {
-        fastReset()
+    preConcat(Matrix().apply {
         rotateX(degree)
     })
 }
@@ -89,8 +85,7 @@ internal fun Matrix.preRotateY(degree : Float) {
     if (degree.absoluteValue < Float.MIN_VALUE) {
         return
     }
-    preConcat(tempMatrixTransform.apply {
-        fastReset()
+    preConcat(Matrix().apply {
         rotateY(degree)
     })
 }
@@ -98,8 +93,7 @@ internal fun Matrix.preRotateZ(degree : Float) {
     if (degree.absoluteValue < Float.MIN_VALUE) {
         return
     }
-    preConcat(tempMatrixTransform.apply {
-        fastReset()
+    preConcat(Matrix().apply {
         rotateZ(degree)
     })
 }

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/utils/Matrix.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/utils/Matrix.kt
@@ -3,9 +3,12 @@ package io.github.alexzhirkevich.compottie.internal.utils
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.graphics.isIdentity
+import kotlin.math.PI
 import kotlin.math.absoluteValue
+import kotlin.math.cos
 import kotlin.math.hypot
 import kotlin.math.roundToInt
+import kotlin.math.sin
 import kotlin.math.sqrt
 
 internal val IdentityMatrix = Matrix()
@@ -72,30 +75,25 @@ internal fun Matrix.preRotate(degree : Float) {
     return rotateZ(degree)
 }
 
-internal fun Matrix.preRotateX(degree : Float) {
-    if (degree.absoluteValue < Float.MIN_VALUE) {
-        return
-    }
-    preConcat(Matrix().apply {
-        rotateX(degree)
-    })
-}
+internal fun Matrix.preRotateX(degree: Float) = preRotateOnAxis(degree, 1, 2)
+internal fun Matrix.preRotateY(degree: Float) = preRotateOnAxis(degree, 2, 0)
+internal fun Matrix.preRotateZ(degree: Float) = preRotateOnAxis(degree, 0, 1)
 
-internal fun Matrix.preRotateY(degree : Float) {
+private fun Matrix.preRotateOnAxis(degree: Float, rowA: Int, rowB: Int) {
     if (degree.absoluteValue < Float.MIN_VALUE) {
         return
     }
-    preConcat(Matrix().apply {
-        rotateY(degree)
-    })
-}
-internal fun Matrix.preRotateZ(degree : Float) {
-    if (degree.absoluteValue < Float.MIN_VALUE) {
-        return
+    val rad = degree.toDouble() * (PI / 180.0)
+    val c = cos(rad).toFloat()
+    val s = sin(rad).toFloat()
+    val v = values
+    for (col in 0..3) {
+        val i = col * 4
+        val a = v[i + rowA]
+        val b = v[i + rowB]
+        v[i + rowA] = c * a - s * b
+        v[i + rowB] = s * a + c * b
     }
-    preConcat(Matrix().apply {
-        rotateZ(degree)
-    })
 }
 
 internal fun Matrix.preScale(x : Float, y : Float) {


### PR DESCRIPTION
When multiple `LottiePainter` instances render concurrently (e.g. several animated elements on screen), two categories of data races cause animations to silently disappear or crash with native heap corruption (`Scudo ERROR: invalid chunk state`).

### Shared composition layers

`LottieCompositionCache` returns the same `LottieComposition` to multiple painters. Without `dynamicProperties`, `deepCopy()` was skipped, so all painters shared the same mutable Skia objects (`Path`, `PathMeasure`, `Matrix`).

**Fix**: Always deep-copy compositions, each painter gets its own layer tree.

### Global mutable temporaries

File-level `val` objects (`tempMatrixConcat`, `tempPath`, `pathMeasure`, etc.) were shared across all painters with no synchronization.

**Fix**: Replace with function-local instances. `preRotateX/Y/Z` go further,  the rotation is computed in-place directly on the backing `values` array so there's no `Matrix()` allocation on every call (these sit in a hot per-layer-per-frame path).

| File | What changed |
|------|-------------|
| `LottiePainter.core.kt` | Always deep-copy, removed dead `copy` variable |
| `Matrix.kt` | Local temp in `preConcat`; zero-alloc in-place `preRotateX/Y/Z` |
| `CompoundTrimPath.kt` | Local `PathMeasure` + `Path` |
| `PlatformPath.android.kt` | Local `android.graphics.Matrix` |
| `PlatformShader.android.kt` | Local `android.graphics.Matrix` |
| `AnimatedShape.kt` | `Path()` instead of shared `EmptyPath` |
| `Layer.kt` | Local `conversionMatrix` |

### Reproduction

Render 8–12 concurrent Lottie animations (e.g. in a `LazyVerticalGrid`). Within seconds, animations begin disappearing. On Android, native heap corruption crashes (`Scudo ERROR: invalid chunk state`) occur intermittently.