### PR TITLE
Migrate to Compose Multiplatform 1.11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.android.build.api.dsl.LibraryExtension
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.FileInputStream
 import java.util.Properties
@@ -131,15 +132,14 @@ fun Project.multiplatformSetup() {
 
         iosArm64()
         iosSimulatorArm64()
-        iosX64()
         macosArm64()
-        macosX64()
 
         js(IR) {
             browser()
         }
 
-        wasmJs() {
+        @OptIn(ExperimentalWasmDsl::class)
+        wasmJs {
             browser()
         }
     }

--- a/compottie-core/build.gradle.kts
+++ b/compottie-core/build.gradle.kts
@@ -1,7 +1,5 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
-import org.jetbrains.compose.ExperimentalComposeLibrary
-
 
 plugins {
     alias(libs.plugins.serialization)
@@ -25,8 +23,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
-            @OptIn(ExperimentalComposeLibrary::class)
-            implementation(compose.uiTest)
+            implementation(libs.compose.ui.test)
         }
         desktopTest.dependencies {
             implementation(compose.desktop.currentOs)

--- a/compottie-core/src/androidMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformPath.android.kt
+++ b/compottie-core/src/androidMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformPath.android.kt
@@ -4,30 +4,36 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.asAndroidPath
-import androidx.compose.ui.graphics.asComposePath
-
 
 internal actual fun ExtendedPathMeasure() : ExtendedPathMeasure = AndroidExtendedPathMeasure(
     android.graphics.PathMeasure()
 )
 
-private val tempAndroidMatrix = android.graphics.Matrix()
-internal actual fun Path.addPath(path: Path, matrix: Matrix) : Path {
-    return asAndroidPath().apply {
-        addPath(
+internal actual class PathBuilder actual constructor() : AutoCloseable {
+    private val androidPath = android.graphics.Path()
+    private val androidMatrix = android.graphics.Matrix()
+
+    actual fun addPath(
+        path: Path,
+        matrix: Matrix
+    ) {
+        androidPath.addPath(
             path.asAndroidPath(),
-            tempAndroidMatrix.apply {
+            androidMatrix.apply {
                 reset()
                 setFromInternal(matrix)
             }
         )
-    }.asComposePath()
-}
-//
-//internal actual fun Path.set(other : Path) {
-//    asAndroidPath().set(other.asAndroidPath())
-//}
+    }
 
+    actual fun setTo(path: Path) {
+        path.asAndroidPath().set(androidPath)
+    }
+
+    actual override fun close() {
+        androidPath.close()
+    }
+}
 
 private class AndroidExtendedPathMeasure(
     private val internalPathMeasure: android.graphics.PathMeasure

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/content/ContentGroupImpl.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/content/ContentGroupImpl.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.util.fastForEachReversed
 import io.github.alexzhirkevich.compottie.internal.AnimationState
 import io.github.alexzhirkevich.compottie.internal.animation.AnimatedTransform
 import io.github.alexzhirkevich.compottie.internal.animation.interpolatedNorm
-import io.github.alexzhirkevich.compottie.internal.platform.addPath
+import io.github.alexzhirkevich.compottie.internal.platform.PathBuilder
 import io.github.alexzhirkevich.compottie.internal.platform.saveLayer
 import io.github.alexzhirkevich.compottie.internal.utils.fastSetFrom
 import io.github.alexzhirkevich.compottie.internal.utils.preConcat
@@ -109,8 +109,11 @@ internal class ContentGroupImpl(
         if (transform != null) {
             matrix.fastSetFrom(transform.matrix(state))
         }
-        pathContents.fastForEachReversed {
-            path.addPath(it.getPath(state), matrix)
+        PathBuilder().use { builder ->
+            pathContents.fastForEachReversed {
+                builder.addPath(it.getPath(state), matrix)
+            }
+            builder.setTo(path)
         }
 
         return path

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformPath.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformPath.kt
@@ -10,12 +10,13 @@ internal interface ExtendedPathMeasure : PathMeasure {
     fun nextContour() : Boolean
 }
 
-internal fun Path.set(other : Path){
+internal fun Path.set(other: Path) {
     reset()
     addPath(other)
 }
-//internal expect fun Path.set(other : Path)
 
-
-internal expect fun Path.addPath(path: Path, matrix: Matrix) : Path
-
+internal expect class PathBuilder() : AutoCloseable {
+    fun addPath(path: Path, matrix: Matrix)
+    fun setTo(path: Path)
+    override fun close()
+}

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/BaseStrokeShape.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/BaseStrokeShape.kt
@@ -37,7 +37,7 @@ import io.github.alexzhirkevich.compottie.internal.helpers.StrokeDash
 import io.github.alexzhirkevich.compottie.internal.helpers.applyTrimPath
 import io.github.alexzhirkevich.compottie.internal.platform.ExtendedPathMeasure
 import io.github.alexzhirkevich.compottie.internal.platform.GradientCache
-import io.github.alexzhirkevich.compottie.internal.platform.addPath
+import io.github.alexzhirkevich.compottie.internal.platform.PathBuilder
 import io.github.alexzhirkevich.compottie.internal.platform.set
 import io.github.alexzhirkevich.compottie.internal.utils.IdentityMatrix
 import io.github.alexzhirkevich.compottie.internal.utils.appendPathEffect
@@ -243,10 +243,13 @@ internal abstract class BaseStrokeShape() : Shape, DrawingContent {
         outBounds: MutableRect,
     ) {
         path.rewind()
-        pathGroups.fastForEach { pathGroup ->
-            pathGroup.paths.fastForEach {
-                path.addPath(it.getPath(state), parentMatrix)
+        PathBuilder().use { builder ->
+            pathGroups.fastForEach { pathGroup ->
+                pathGroup.paths.fastForEach {
+                    builder.addPath(it.getPath(state), parentMatrix)
+                }
             }
+            builder.setTo(path)
         }
 
         outBounds.set(path.getBounds())

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/FillShape.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/FillShape.kt
@@ -26,7 +26,7 @@ import io.github.alexzhirkevich.compottie.internal.effects.LayerEffectsState
 import io.github.alexzhirkevich.compottie.internal.helpers.FillRule
 import io.github.alexzhirkevich.compottie.internal.helpers.asPathFillType
 import io.github.alexzhirkevich.compottie.internal.platform.GradientCache
-import io.github.alexzhirkevich.compottie.internal.platform.addPath
+import io.github.alexzhirkevich.compottie.internal.platform.PathBuilder
 import io.github.alexzhirkevich.compottie.internal.utils.extendBy
 import io.github.alexzhirkevich.compottie.internal.utils.set
 import io.github.alexzhirkevich.keight.ScriptRuntime
@@ -129,8 +129,11 @@ internal class FillShape(
         path.rewind()
         path.fillType = fillType
 
-        paths.fastForEach {
-            path.addPath(it.getPath(state), parentMatrix)
+        PathBuilder().use { builder ->
+            paths.fastForEach {
+                builder.addPath(it.getPath(state), parentMatrix)
+            }
+            builder.setTo(path)
         }
 
         drawScope.drawContext.canvas.drawPath(path, paint)
@@ -144,8 +147,11 @@ internal class FillShape(
     ) {
 
         path.rewind()
-        paths.fastForEach {
-            path.addPath(it.getPath(state), parentMatrix)
+        PathBuilder().use { builder ->
+            paths.fastForEach {
+                builder.addPath(it.getPath(state), parentMatrix)
+            }
+            builder.setTo(path)
         }
 
         outBounds.set(path.getBounds())

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/GradientFillShape.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/GradientFillShape.kt
@@ -28,7 +28,7 @@ import io.github.alexzhirkevich.compottie.internal.helpers.GradientType
 import io.github.alexzhirkevich.compottie.internal.helpers.asPathFillType
 import io.github.alexzhirkevich.compottie.internal.platform.GradientCache
 import io.github.alexzhirkevich.compottie.internal.platform.GradientShader
-import io.github.alexzhirkevich.compottie.internal.platform.addPath
+import io.github.alexzhirkevich.compottie.internal.platform.PathBuilder
 import io.github.alexzhirkevich.compottie.internal.utils.IdentityMatrix
 import io.github.alexzhirkevich.compottie.internal.utils.extendBy
 import io.github.alexzhirkevich.compottie.internal.utils.firstInstanceOf
@@ -143,8 +143,11 @@ internal class GradientFillShape(
         path.rewind()
         path.fillType = fillType
 
-        pathContents.fastForEach {
-            path.addPath(it.getPath(state), parentMatrix)
+        PathBuilder().use { builder ->
+            pathContents.fastForEach {
+                builder.addPath(it.getPath(state), parentMatrix)
+            }
+            builder.setTo(path)
         }
 
         roundShape?.applyTo(paint, state)
@@ -160,8 +163,11 @@ internal class GradientFillShape(
         outBounds: MutableRect
     ) {
         path.rewind()
-        pathContents.fastForEach {
-            path.addPath(it.getPath(state), parentMatrix)
+        PathBuilder().use { builder ->
+            pathContents.fastForEach {
+                builder.addPath(it.getPath(state), parentMatrix)
+            }
+            builder.setTo(path)
         }
         outBounds.set(path.getBounds())
         outBounds.extendBy(1f)

--- a/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/RepeaterShape.kt
+++ b/compottie-core/src/commonMain/kotlin/io/github/alexzhirkevich/compottie/internal/shapes/RepeaterShape.kt
@@ -20,7 +20,7 @@ import io.github.alexzhirkevich.compottie.internal.content.DrawingContent
 import io.github.alexzhirkevich.compottie.internal.content.GreedyContent
 import io.github.alexzhirkevich.compottie.internal.content.PathContent
 import io.github.alexzhirkevich.compottie.internal.content.nameOrDefault
-import io.github.alexzhirkevich.compottie.internal.platform.addPath
+import io.github.alexzhirkevich.compottie.internal.platform.PathBuilder
 import io.github.alexzhirkevich.compottie.internal.utils.fastSetFrom
 import io.github.alexzhirkevich.compottie.internal.utils.preConcat
 import kotlinx.serialization.SerialName
@@ -100,9 +100,12 @@ internal class RepeaterShape(
         val copies = copies.interpolatedFloat(state)
         val offset = offset.interpolatedFloat(state)
 
-        for (i in copies.toInt() - 1 downTo 0) {
-            matrix.fastSetFrom(transform.repeaterMatrix(state, i + offset))
-            path.addPath(contentPath, matrix)
+        PathBuilder().use { builder ->
+            for (i in copies.toInt() - 1 downTo 0) {
+                matrix.fastSetFrom(transform.repeaterMatrix(state, i + offset))
+                builder.addPath(contentPath, matrix)
+            }
+            builder.setTo(path)
         }
         return path
     }

--- a/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformCanvas.skiko.kt
+++ b/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformCanvas.skiko.kt
@@ -3,16 +3,17 @@ package io.github.alexzhirkevich.compottie.internal.platform
 import androidx.compose.ui.geometry.MutableRect
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.skiaCanvas
+import androidx.compose.ui.graphics.skiaPaint
 
 internal actual fun Canvas.saveLayer(rect : MutableRect, paint : Paint, flag : Int) {
     try {
-        nativeCanvas.saveLayer(
+        skiaCanvas.saveLayer(
             left = rect.left,
             top = rect.top,
             right = rect.right,
             bottom = rect.bottom,
-            paint = paint.asFrameworkPaint()
+            paint = paint.skiaPaint
         )
     } catch (t : ClassCastException) {
     }

--- a/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformPath.skiko.kt
+++ b/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformPath.skiko.kt
@@ -3,9 +3,9 @@ package io.github.alexzhirkevich.compottie.internal.platform
 import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathMeasure
-import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.asSkiaPathMeasure
+import org.jetbrains.skia.PathBuilder
 
 internal actual fun ExtendedPathMeasure() : ExtendedPathMeasure = SkikoExtendedPathMeasure()
 
@@ -18,5 +18,23 @@ private class SkikoExtendedPathMeasure(
     }
 }
 
-internal actual fun Path.addPath(path: Path, matrix: Matrix) =
-    asSkiaPath().addPath(path.asSkiaPath(), matrix = matrix.asSkia33()).asComposePath()
+internal actual class PathBuilder actual constructor() : AutoCloseable {
+    private val skikoPathBuilder = PathBuilder()
+
+    actual fun addPath(
+        path: Path,
+        matrix: Matrix
+    ) {
+        skikoPathBuilder.addPath(path.asSkiaPath(), matrix = matrix.asSkia33())
+    }
+
+    actual fun setTo(path: Path) {
+        val snapshot = skikoPathBuilder.snapshot()
+        path.asSkiaPath().swap(snapshot)
+        snapshot.close()
+    }
+
+    actual override fun close() {
+        skikoPathBuilder.close()
+    }
+}

--- a/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformShader.skiko.kt
+++ b/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/PlatformShader.skiko.kt
@@ -1,16 +1,13 @@
 package io.github.alexzhirkevich.compottie.internal.platform
 
-import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.ColorMatrix
-import androidx.compose.ui.graphics.ColorMatrixColorFilter
 import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Shader
 import androidx.compose.ui.graphics.TileMode
-import androidx.compose.ui.graphics.TileMode.Companion.Clamp
-import androidx.compose.ui.graphics.asComposeColorFilter
+import androidx.compose.ui.graphics.asComposeShader
+import androidx.compose.ui.graphics.skiaPaint
 import androidx.compose.ui.graphics.toArgb
 import org.jetbrains.skia.FilterBlurMode
 import org.jetbrains.skia.FilterTileMode
@@ -18,10 +15,8 @@ import org.jetbrains.skia.GradientStyle
 import org.jetbrains.skia.ImageFilter
 import org.jetbrains.skia.MaskFilter
 import org.jetbrains.skia.Matrix33
-import org.jetbrains.skia.Shader
-import kotlin.math.PI
 import kotlin.math.abs
-import kotlin.math.sqrt
+import org.jetbrains.skia.Shader as SkShader
 
 internal actual fun MakeLinearGradient(
     from : Offset,
@@ -32,7 +27,7 @@ internal actual fun MakeLinearGradient(
     matrix: Matrix
 ) : Shader {
     return try {
-        Shader.makeLinearGradient(
+        SkShader.makeLinearGradient(
             x0 = from.x,
             y0 = from.y,
             x1 = to.x,
@@ -44,7 +39,15 @@ internal actual fun MakeLinearGradient(
                 isPremul = true,
                 localMatrix = matrix.asSkia33(coerceScale = true)
             )
-        )
+            // TODO: Migrate to new Gradient API introduced in skiko 0.146 (Compose 1.12)
+            // gradient = Gradient(
+            //     Gradient.Colors(
+            //         colors = colors.toColor4fArray(),
+            //         positions = colorStops.toFloatArray(),
+            //         tileMode = FilterTileMode.CLAMP
+            //     )
+            // ),
+        ).asComposeShader()
     }catch (t : Throwable){
         throw t
     }
@@ -57,7 +60,7 @@ internal actual fun MakeRadialGradient(
     colorStops: List<Float>,
     tileMode: TileMode,
     matrix: Matrix
-) = Shader.makeRadialGradient(
+) = SkShader.makeRadialGradient(
     x = center.x,
     y = center.y,
     r = radius,
@@ -68,7 +71,20 @@ internal actual fun MakeRadialGradient(
         isPremul = true,
         localMatrix = matrix.asSkia33(coerceScale = true)
     )
-)
+    // TODO: Migrate to new Gradient API introduced in skiko 0.146 (Compose 1.12)
+    // radius = radius,
+    // gradient = Gradient(
+    //     colors = Gradient.Colors(
+    //         colors = colors.toColor4fArray(),
+    //         positions = colorStops.toFloatArray(),
+    //         tileMode = tileMode.toSkiaTileMode()
+    //     ),
+    //     interpolation = Gradient.Interpolation(
+    //         inPremul = Gradient.Interpolation.InPremul.YES
+    //     )
+    // ),
+    // localMatrix = matrix.asSkia33(coerceScale = true),
+).asComposeShader()
 
 
 internal fun Matrix.asSkia33(coerceScale : Boolean = false) : Matrix33 {
@@ -102,8 +118,15 @@ internal fun Matrix.asSkia33(coerceScale : Boolean = false) : Matrix33 {
 private fun List<Color>.toIntArray(): IntArray =
     IntArray(size) { i -> this[i].toArgb() }
 
+// TODO: Migrate to new Gradient API introduced in skiko 0.146 (Compose 1.12)
+//private fun List<Color>.toColor4fArray(): Array<Color4f> =
+//    Array(size) { i ->
+//        val color = this[i]
+//        Color4f(color.red, color.green, color.blue, color.alpha)
+//    }
+
 internal fun TileMode.toSkiaTileMode(): FilterTileMode = when (this) {
-    Clamp -> FilterTileMode.CLAMP
+    TileMode.Clamp -> FilterTileMode.CLAMP
     TileMode.Repeated -> FilterTileMode.REPEAT
     TileMode.Mirror -> FilterTileMode.MIRROR
     TileMode.Decal -> FilterTileMode.DECAL
@@ -115,7 +138,7 @@ internal fun TileMode.toSkiaTileMode(): FilterTileMode = when (this) {
 
 
 internal actual fun Paint.setBlurMaskFilter(radius: Float, isImage : Boolean) {
-    val skPaint = asFrameworkPaint()
+    val skPaint = skiaPaint
 
     val sigma = if (radius > 0) {
         BlurSigmaScale * radius

--- a/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/effects/PlatformDropShadowEffect.skiko.kt
+++ b/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/effects/PlatformDropShadowEffect.skiko.kt
@@ -2,6 +2,7 @@ package io.github.alexzhirkevich.compottie.internal.platform.effects
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.skiaPaint
 import androidx.compose.ui.graphics.toArgb
 import io.github.alexzhirkevich.compottie.internal.platform.BlurSigmaScale
 import org.jetbrains.skia.ImageFilter
@@ -27,7 +28,7 @@ internal actual fun makeNativeDropShadowEffect(
 internal actual fun Paint.applyNativeDropShadowEffect(
     effect: PlatformDropShadowEffect,
 ) {
-    val fp = asFrameworkPaint()
+    val fp = skiaPaint
 
     if (fp.imageFilter == null) {
         fp.imageFilter = effect.filter

--- a/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/effects/PlatformLayerEffect.skiko.kt
+++ b/compottie-core/src/skikoMain/kotlin/io/github/alexzhirkevich/compottie/internal/platform/effects/PlatformLayerEffect.skiko.kt
@@ -1,7 +1,8 @@
 package io.github.alexzhirkevich.compottie.internal.platform.effects
 
 import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.skiaPaint
 
 internal actual fun Paint.resetEffects() {
-    asFrameworkPaint().imageFilter = null
+    skiaPaint.imageFilter = null
 }

--- a/compottie-lite/build.gradle.kts
+++ b/compottie-lite/build.gradle.kts
@@ -1,7 +1,5 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
-import org.jetbrains.compose.ExperimentalComposeLibrary
-
 
 plugins {
     alias(libs.plugins.compose)
@@ -18,8 +16,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
-            @OptIn(ExperimentalComposeLibrary::class)
-            implementation(compose.uiTest)
+            implementation(libs.compose.ui.test)
         }
         desktopTest.dependencies {
             implementation(compose.desktop.currentOs)

--- a/compottie-resources/build.gradle.kts
+++ b/compottie-resources/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
         commonMain.dependencies {
             api(project(":compottie-core"))
             implementation(libs.compose.ui)
-            implementation(compose.components.resources)
+            implementation(libs.compose.resources)
             implementation(libs.coroutines.core)
         }
     }

--- a/example/androidApp/build.gradle.kts
+++ b/example/androidApp/build.gradle.kts
@@ -40,8 +40,8 @@ dependencies {
     implementation(project(":compottie"))
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity.compose)
-    implementation(compose.uiTooling)
-    implementation(compose.preview)
+    implementation(libs.compose.ui.tooling)
+    implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.foundation)
-    implementation(compose.components.resources)
+    implementation(libs.compose.resources)
 }

--- a/example/shared/build.gradle.kts
+++ b/example/shared/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class)
 
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -47,7 +48,6 @@ kotlin {
 
     listOf(
         iosArm64(),
-        iosX64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
         iosTarget.binaries.framework {
@@ -55,14 +55,14 @@ kotlin {
         }
     }
     macosArm64()
-    macosX64()
     jvm()
 
     js(IR) {
         browser()
     }
 
-    wasmJs() {
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
         browser()
     }
 
@@ -84,7 +84,7 @@ kotlin {
 
 
             implementation(libs.compose.material3)
-            implementation(compose.components.resources)
+            implementation(libs.compose.resources)
             implementation(libs.serialization)
             implementation(libs.coil.compose)
             implementation(libs.coil.network)

--- a/example/webApp/build.gradle.kts
+++ b/example/webApp/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -18,6 +20,7 @@ kotlin {
         binaries.executable()
     }
 
+    @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()
         binaries.executable()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 androidx-activity-compose="1.10.1"
 androidx-core-ktx="1.17.0"
 collection="1.5.0"
-kotlin="2.3.0"
-compose="1.10.1"
-androidx-lifecycle="2.10.0-alpha07"
-material3="1.10.0-alpha05"
+kotlin="2.3.20"
+compose="1.11.0-beta03"
+androidx-lifecycle="2.10.0"
+material3="1.11.0-alpha06"
 agp = "8.12.1"
 okio = "3.16.4"
 serialization="1.9.0"
@@ -20,6 +20,10 @@ kotlinx-browser="0.5.0"
 [libraries]
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
+compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose" }
+compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose" }
+compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose" }
+compose-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 androidx-collection = { module = "androidx.collection:collection", version.ref = "collection" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
         google()
         gradlePluginPortal()
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven("https://redirector.kotlinlang.org/maven/compose-dev")
     }
 }
 
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven("https://redirector.kotlinlang.org/maven/compose-dev")
         maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
 //        mavenLocal()
     }


### PR DESCRIPTION
Should fix #73 and #74

- Update Compose Multiplatform to 1.11
- Update Kotlin to 2.3.20 (required for Web - no forward compatibility even for patches)
- Remove iOS and macOS x64 targets (dropped in base libraries)
- Migrate to `PathBuilder` skia pattern
- Migrate to new `Shader` wrapper API
- Migrate from deprecated `asFrameworkPaint()`, `nativeCanvas` APIs
- Migrate from deprecated aliases in Compose gradle plugin to the version catalog